### PR TITLE
Set use_reloader=False

### DIFF
--- a/nautilus/services/service.py
+++ b/nautilus/services/service.py
@@ -130,7 +130,11 @@ class Service:
                 registry.keep_alive(self)
 
             # run the service at the designated port
-            self.app.run(host=self.app.config['HOST'], port=self.app.config['PORT'])
+            self.app.run(
+                         host=self.app.config['HOST'],
+                         port=self.app.config['PORT'],
+                         use_reloader=False
+            )
 
             # app.run is blocking while the server is running
             # lines afterwards are executed when the server stop


### PR DESCRIPTION
Auto code reloading does not work with the consul service
registration, it reregisters the service.